### PR TITLE
Fix fs.unlink() usage

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -179,8 +179,9 @@ const commands = {
     };
 
     const finalize = () => {
-      fs.unlink('./run.pid');
-      doExit();
+      fs.unlink('./run.pid', () => {
+        doExit();
+      });
     };
 
     if (isWin) {


### PR DESCRIPTION
Starting with Node.js v10.0.0 `callback` argument in `fs.unlink()` is
no longer optional.

Refs: https://github.com/metarhia/impress/issues/852